### PR TITLE
[Fix] Empty Redirect URI

### DIFF
--- a/src/main/java/org/wso2/keycloak/client/KeycloakClient.java
+++ b/src/main/java/org/wso2/keycloak/client/KeycloakClient.java
@@ -565,8 +565,11 @@ public class KeycloakClient extends AbstractKeyManager {
         }
 
         String clientRedirectUri = oAuthApplicationInfo.getCallBackURL();
-        List<String> redirectUris = Collections.singletonList(clientRedirectUri);
-        paramMap.put(KeycloakConstants.CLIENT_REDIRECT_URIS, redirectUris);
+        if (!StringUtils.isNotEmpty(clientRedirectUri)) {
+            List<String> redirectUris = Collections.singletonList(clientRedirectUri);
+            paramMap.put(KeycloakConstants.CLIENT_REDIRECT_URIS, redirectUris);
+        }
+        
         Object clientGrantTypes = oAuthApplicationInfo.getParameter(KeycloakConstants.CLIENT_GRANT_TYPES);
         if (clientGrantTypes != null) {
             List<String> grantTypes = Arrays.asList(((String) clientGrantTypes).split(","));


### PR DESCRIPTION
## Purpose

Enhancement to ignore adding Redirect URI when trying to create application (generating the tokens for the very first time) & update application. Otherwise, empty Redirect URI ([null]) values will result in 500 Internal Server errors from the Keycloak Server when trying to create or update the Application from the Store.

Fix for #6 

Following is the error-trace when not handled

```log
[2020-05-03 00:46:40,363] ERROR - KeycloakClient Error occured while registering the new client in Keycloak. Response : 500
[2020-05-03 00:46:40,368] ERROR - APIUtil Error occurred while executing SubscriberKeyMgtClient.
org.wso2.carbon.apimgt.api.APIManagementException: Error occured while registering the new client in Keycloak. Response : 500
	at org.wso2.keycloak.client.KeycloakClient.handleException(KeycloakClient.java:660)
	at org.wso2.keycloak.client.KeycloakClient.createApplication(KeycloakClient.java:137)
	at org.wso2.carbon.apimgt.impl.workflow.AbstractApplicationRegistrationWorkflowExecutor.dogenerateKeysForApplication_aroundBody8(AbstractApplicationRegistrationWorkflowExecutor.java:145)
	at org.wso2.carbon.apimgt.impl.workflow.AbstractApplicationRegistrationWorkflowExecutor.dogenerateKeysForApplication(AbstractApplicationRegistrationWorkflowExecutor.java:124)
	at org.wso2.carbon.apimgt.impl.workflow.AbstractApplicationRegistrationWorkflowExecutor.generateKeysForApplication_aroundBody6(AbstractApplicationRegistrationWorkflowExecutor.java:120)
	at org.wso2.carbon.apimgt.impl.workflow.AbstractApplicationRegistrationWorkflowExecutor.generateKeysForApplication(AbstractApplicationRegistrationWorkflowExecutor.java:117)
	at org.wso2.carbon.apimgt.impl.workflow.ApplicationRegistrationSimpleWorkflowExecutor.complete_aroundBody2(ApplicationRegistrationSimpleWorkflowExecutor.java:78)
	at org.wso2.carbon.apimgt.impl.workflow.ApplicationRegistrationSimpleWorkflowExecutor.complete(ApplicationRegistrationSimpleWorkflowExecutor.java:66)
	at org.wso2.carbon.apimgt.impl.workflow.ApplicationRegistrationSimpleWorkflowExecutor.execute_aroundBody0(ApplicationRegistrationSimpleWorkflowExecutor.java:54)
	at org.wso2.carbon.apimgt.impl.workflow.ApplicationRegistrationSimpleWorkflowExecutor.execute(ApplicationRegistrationSimpleWorkflowExecutor.java:47)
	at org.wso2.carbon.apimgt.impl.APIConsumerImpl.requestApprovalForApplicationRegistration_aroundBody108(APIConsumerImpl.java:3107)
	at org.wso2.carbon.apimgt.impl.APIConsumerImpl.requestApprovalForApplicationRegistration(APIConsumerImpl.java:2976)
	at org.wso2.carbon.apimgt.hostobjects.APIStoreHostObject.jsFunction_getApplicationKey(APIStoreHostObject.java:349)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:126)
	at org.mozilla.javascript.FunctionObject.call(FunctionObject.java:386)
	at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:52)
	at org.jaggeryjs.rhino.store.modules.subscription.c2._c_anonymous_2(/store/modules/subscription/key.jag:41)
	at org.jaggeryjs.rhino.store.modules.subscription.c2.call(/store/modules/subscription/key.jag)
	at org.mozilla.javascript.ScriptRuntime.applyOrCall(ScriptRuntime.java:2430)
	at org.mozilla.javascript.BaseFunction.execIdCall(BaseFunction.java:269)
	at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:97)
	at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:42)
	at org.jaggeryjs.rhino.store.modules.subscription.c0._c_anonymous_10(/store/modules/subscription/module.jag:35)
	at org.jaggeryjs.rhino.store.modules.subscription.c0.call(/store/modules/subscription/module.jag)
	at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:52)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0._c_anonymous_1(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag:240)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0.call(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag)
	at org.mozilla.javascript.optimizer.OptRuntime.call0(OptRuntime.java:23)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0._c_script_0(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag:3)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0.call(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag)
	at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:394)
	at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3091)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0.call(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag)
	at org.jaggeryjs.rhino.store.site.blocks.subscription.subscription_add.ajax.c0.exec(/store/site/blocks/subscription/subscription-add/ajax/subscription-add.jag)
	at org.jaggeryjs.scriptengine.engine.RhinoEngine.execScript(RhinoEngine.java:567)
	at org.jaggeryjs.scriptengine.engine.RhinoEngine.exec(RhinoEngine.java:273)
	at org.jaggeryjs.jaggery.core.manager.WebAppManager.exec(WebAppManager.java:588)
	at org.jaggeryjs.jaggery.core.manager.WebAppManager.execute(WebAppManager.java:508)
	at org.jaggeryjs.jaggery.core.JaggeryServlet.doPost(JaggeryServlet.java:29)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:650)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:743)
	at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:485)
	at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:377)
	at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:337)
	at org.jaggeryjs.jaggery.core.JaggeryFilter.doFilter(JaggeryFilter.java:21)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter.doFilter(ContentTypeBasedCachePreventionFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:110)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:494)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:169)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:104)
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:80)
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:100)
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:65)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
	at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
	at org.wso2.carbon.event.receiver.core.internal.tenantmgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:48)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:1025)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:445)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1137)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:637)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1775)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1734)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
[2020-05-03 00:46:40,375] ERROR - ApplicationRegistrationSimpleWorkflowExecutor Error occurred when updating the status of the Application creation process
```