### PR TITLE
Supporting `subject_type`

### DIFF
--- a/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeyCloakConnectorConfiguration.java
+++ b/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeyCloakConnectorConfiguration.java
@@ -56,6 +56,9 @@ public class KeyCloakConnectorConfiguration implements KeyManagerConnectorConfig
                         false, Arrays.asList("code", "none", "id_token", "token", "id_token token", "code id_token",
                         "code token", "code id_token token"), true));
         configurationDtoList
+                .add(new ConfigurationDto("subject_type", "Subject Type", "select", "Subject Type of Client", 
+                        "pairwise", true, false, Arrays.asList("public", "pairwise"), false));
+        configurationDtoList
                 .add(new ConfigurationDto("token_endpoint_auth_method", "Token endpoint Authentication Method",
                         "select", "How to Authenticate Token Endpoint", "client_secret_basic", true,
                         false,


### PR DESCRIPTION
## Purpose

Adding support for `subject_type` property configuration for Keycloak connector to configure through the Devportal view when creating/updating clients.