### PR TITLE
Fix introspect token validation related invocation failure

### DIFF
--- a/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeycloakClient.java
+++ b/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeycloakClient.java
@@ -231,13 +231,16 @@ public class KeycloakClient extends AbstractKeyManager {
 
         org.wso2.carbon.apimgt.api.model.AccessTokenInfo tokenInfo =
                 new org.wso2.carbon.apimgt.api.model.AccessTokenInfo();
-        IntrospectInfo introspectInfo =
-                introspectionClient.introspect(accessToken, KeycloakConstants.REQUESTING_PARTY_TOKEN);
+        IntrospectInfo introspectInfo = introspectionClient.introspect(accessToken,
+                KeycloakConstants.INTROSPECTION_TOKEN_TYPE_HINT_ACCESS_TOKEN);
         if (introspectInfo != null) {
             tokenInfo.setAccessToken(accessToken);
             tokenInfo.setTokenValid(introspectInfo.isActive());
-            tokenInfo.setIssuedTime(introspectInfo.getIssuedAt());
-            tokenInfo.setValidityPeriod(introspectInfo.getExpiryTime() - introspectInfo.getIssuedAt());
+            if (introspectInfo.getIssuedAt() > 0 && introspectInfo.getExpiryTime() > 0) {
+                tokenInfo.setIssuedTime(introspectInfo.getIssuedAt() * 1000L);
+                long validityPeriod = introspectInfo.getExpiryTime() - introspectInfo.getIssuedAt();
+                tokenInfo.setValidityPeriod(validityPeriod * 1000L);
+            }
             tokenInfo.setEndUserName(introspectInfo.getUsername());
             tokenInfo.setConsumerKey(introspectInfo.getConsumerKey());
             if (StringUtils.isNotEmpty(introspectInfo.getScope())) {

--- a/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeycloakConstants.java
+++ b/components/keycloak.key.manager/src/main/java/org/wso2/keycloak/client/KeycloakConstants.java
@@ -47,7 +47,7 @@ public class KeycloakConstants {
     public static final String CLIENT_TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method";
     public static final String TLS_CLIENT_CERTIFICATE_BOUND_ACCESS_TOKEN = "tls_client_certificate_bound_access_tokens";
     public static final String KEY_CLOAK_TYPE = "KeyCloak";
-    public static final String REQUESTING_PARTY_TOKEN = "requesting_party_token";
+    public static final String INTROSPECTION_TOKEN_TYPE_HINT_ACCESS_TOKEN = "access_token";
 
     KeycloakConstants() {
     }


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/4469

This pull request updates the Keycloak integration to improve how access token metadata is retrieved and processed. The main changes involve using the correct token type hint during token introspection and ensuring issued and expiry times are handled in milliseconds, with proper handling for tokens that do not expire.

**Keycloak token introspection improvements:**

* Changed the token type hint used in the introspection call from `requesting_party_token` to `access_token` by introducing the new constant `INTROSPECTION_TOKEN_TYPE_HINT_ACCESS_TOKEN` in `KeycloakConstants.java` and updating its usage in `KeycloakClient.java`. [[1]](diffhunk://#diff-6e8fa03adffdc6eb186a8dd6807e8874d5f439242742b3af8fe59d27a4627035L50-R50) [[2]](diffhunk://#diff-3c3affe9d6c87f00591ca3b1ec643feb989030ae75a4c3851306ac46356005ccL234-R247)

**Access token metadata handling:**

* Updated the calculation of issued time and validity period for access tokens in `KeycloakClient.java` to convert values from seconds to milliseconds, and to handle tokens with no expiry by setting validity to `Long.MAX_VALUE`.