### PR TITLE
Add missing project-level <name> tag to keycloak.key.manager pom

### DIFF
--- a/components/keycloak.key.manager/pom.xml
+++ b/components/keycloak.key.manager/pom.xml
@@ -9,6 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
     <artifactId>keycloak.key.manager</artifactId>
+    <name>KeyCloak Key Manager Component</name>
     <dependencies>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
## Purpose
Migrating publishing from Nexus 2 to Nexus 3. Nexus 3 build **fails** when a pom's project-level `<name>` tag is missing (Nexus 2 tolerated it).

## Changes
- `components/keycloak.key.manager/pom.xml` — added project-level `<name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)